### PR TITLE
Bump the version number for the Django 1.8 upgrade.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='edx-organizations',
-    version='0.1.7',
+    version='0.1.8',
     description='Organization management module for Open edX',
     long_description=open('README.md').read(),
     author='edX',


### PR DESCRIPTION
@mattdrayer @edx/django-team  The version number of this repo had changed to the exact same version to which the Django 1.8 branch changed it. (0.1.7) In order to install the module properly with the new Django 1.8 work, we need to bump the version number.

Please review.