### PR TITLE
added new api to fetch organization by short name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ script:
     - coverage run ./manage.py test organizations
     - coverage report -m
     - pep8 --config=.pep8 organizations
-    - pylint --rcfile=.pylintrc organizations --report=no
+    - pylint --rcfile=.pylintrc organizations --reports=no
 
 # Post results to Coveralls.io
 after_success: coveralls

--- a/organizations/api.py
+++ b/organizations/api.py
@@ -59,6 +59,13 @@ def get_organization(organization_id):
     return data.fetch_organization(organization_id)
 
 
+def get_organization_by_short_name(organization_short_name):
+    """
+    Retrieves the organization filtered by short name
+    """
+    return data.fetch_organization_by_short_name(organization_short_name)
+
+
 def get_organizations():
     """
     Retrieves the active organizations managed by the system

--- a/organizations/data.py
+++ b/organizations/data.py
@@ -168,6 +168,22 @@ def fetch_organization(organization_id):
     return organizations[0]
 
 
+def fetch_organization_by_short_name(organization_short_name):
+    """
+    Retrieves a specific organization from app/local state by short name
+    Returns a dictionary representation of the object
+    """
+    organization = {'short_name': organization_short_name}
+    if not organization_short_name:
+        exceptions.raise_exception("organization", organization, exceptions.InvalidOrganizationException)
+    organizations = serializers.serialize_organizations(internal.Organization.objects.filter(
+        active=True, short_name=organization_short_name
+    ))
+    if not len(organizations):
+        exceptions.raise_exception("organization", organization, exceptions.InvalidOrganizationException)
+    return organizations[0]
+
+
 def fetch_organizations():
     """
     Retrieves the set of active organizations from app/local state

--- a/organizations/models.py
+++ b/organizations/models.py
@@ -8,8 +8,8 @@ offers one programmatic API -- api.py for direct Python integration.
 """
 
 from django.db import models
-from model_utils.models import TimeStampedModel
 from django.utils.translation import ugettext_lazy as _
+from model_utils.models import TimeStampedModel
 
 
 class Organization(TimeStampedModel):

--- a/organizations/tests/test_admin.py
+++ b/organizations/tests/test_admin.py
@@ -4,12 +4,12 @@
 """
 Organizations Admin Module Test Cases
 """
-import organizations.tests.utils as utils
 from django.contrib.admin.sites import AdminSite
-from organizations.admin import OrganizationAdmin, OrganizationCourseAdmin
-from organizations.models import (Organization, OrganizationCourse)
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.http import HttpRequest
+import organizations.tests.utils as utils
+from organizations.admin import OrganizationAdmin, OrganizationCourseAdmin
+from organizations.models import (Organization, OrganizationCourse)
 
 
 def create_organization(active=True):

--- a/organizations/tests/test_api.py
+++ b/organizations/tests/test_api.py
@@ -125,6 +125,31 @@ class OrganizationsApiTestCase(utils.OrganizationsTestCaseBase):
         self.assertEqual(organization['name'], self.test_organization['name'])
         self.assertEqual(organization['description'], self.test_organization['description'])
 
+    def test_get_organization_by_short_name(self):
+        """ Unit Test: get_organization_by_short_name"""
+        api.add_organization({
+            'name': 'local_organization_1ßßß',
+            'short_name': 'Orgx1',
+            'description': 'Local Organization 1 Descriptionßßß'
+        })
+        api.add_organization({
+            'name': 'local_organization_2',
+            'short_name': 'Orgx2',
+            'description': 'Local Organization 2'
+        })
+        with self.assertNumQueries(1):
+            organization = api.get_organization_by_short_name('Orgx2')
+        self.assertEqual(organization['name'], 'local_organization_2')
+        self.assertEqual(organization['description'], 'Local Organization 2')
+
+        with self.assertNumQueries(0):
+            with self.assertRaises(exceptions.InvalidOrganizationException):
+                api.get_organization_by_short_name(None)
+
+        with self.assertNumQueries(1):
+            with self.assertRaises(exceptions.InvalidOrganizationException):
+                api.get_organization_by_short_name('not_existing')
+
     def test_get_organizations(self):
         """ Unit Test: test_get_organizations """
         api.add_organization({

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ django_nose==1.4.1
 nose==1.3.3
 httpretty==0.8.0
 pep8==1.5.7
-pylint==1.2.1
+pylint==1.5.0
 pep257==0.3.2
 mock==1.0.1
 testfixtures==4.0.0

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='edx-organizations',
-    version='0.1.9',
+    version='0.2.0',
     description='Organization management module for Open edX',
     long_description=open('README.md').read(),
     author='edX',


### PR DESCRIPTION
This PR adds a new api named `get_organization_by_short_name` which returns and organization object  for a given short name. It also has some changes to make pylint/travis happy.
@asadiqbal08  could you please review it.
@mattdrayer FYI.