### PR TITLE
Updated help_text for Organization.logo field

### DIFF
--- a/organizations/__init__.py
+++ b/organizations/__init__.py
@@ -1,4 +1,4 @@
 """
 edx-organizations app initialization module
 """
-__version__ = '0.4.1'  # pragma: no cover
+__version__ = '0.4.2'  # pragma: no cover

--- a/organizations/migrations/0002_auto_20170117_1434.py
+++ b/organizations/migrations/0002_auto_20170117_1434.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('organizations', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='organization',
+            name='logo',
+            field=models.ImageField(help_text='Please add only .PNG files for logo images. This logo will be used on certificates.', max_length=255, null=True, upload_to=b'organization_logos', blank=True),
+        ),
+    ]

--- a/organizations/models.py
+++ b/organizations/models.py
@@ -11,7 +11,7 @@ from model_utils.models import TimeStampedModel
 
 class Organization(TimeStampedModel):
     """
-    An Organizatio is a representation of an entity which publishes/provides
+    An Organization is a representation of an entity which publishes/provides
     one or more courses delivered by the LMS. Organizations have a base set of
     metadata describing the organization, including id, name, and description.
     """
@@ -20,7 +20,7 @@ class Organization(TimeStampedModel):
     description = models.TextField()
     logo = models.ImageField(
         upload_to='organization_logos',
-        help_text=_(u'Please add only .PNG files for logo images.'),
+        help_text=_('Please add only .PNG files for logo images. This logo will be used on certificates.'),
         null=True, blank=True, max_length=255
     )
     active = models.BooleanField(default=True)

--- a/setup.py
+++ b/setup.py
@@ -24,11 +24,12 @@ setup(
     packages=find_packages(exclude=['tests']),
     install_requires=[
         'django>=1.8,<1.9',
-        'django-model-utils>=1.4.0,<1.5.0',
+        'django-model-utils>=1.4.0',
         'djangorestframework>=3.2.0,<3.4.0',
-        'edx-opaque-keys>=0.1.2,<1.0.0',
         'djangorestframework-oauth>=1.1.0,<2.0.0',
         'edx-django-oauth2-provider>=0.5.0,<1.0.0',
         'edx-drf-extensions>=0.5.1,<1.0.0',
+        'edx-opaque-keys>=0.1.2,<1.0.0',
+        'Pillow',
     ],
 )


### PR DESCRIPTION
The help text now reflects the fact that this field is used for the certificate image. Requirements have also been updated to include Pillow, needed for the ImageField.

ECOM-6862