### PR TITLE
ENT-585 Fix get_organization bug.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@ Matt Drayer <mattdrayer@edx.org>
 Zia Fazal <zfazal@edx.org>
 Ahsan Ulhaq <ahsan.ulhaq84@gmail.com>
 Christina Roberts <christina@edx.org>
+Douglas Hall <dhall@edx.org>

--- a/organizations/__init__.py
+++ b/organizations/__init__.py
@@ -1,4 +1,4 @@
 """
 edx-organizations app initialization module
 """
-__version__ = '0.4.5'  # pragma: no cover
+__version__ = '0.4.6'  # pragma: no cover

--- a/organizations/data.py
+++ b/organizations/data.py
@@ -162,7 +162,9 @@ def fetch_organization(organization_id):
     organization = {'id': organization_id}
     if not organization_id:
         exceptions.raise_exception("organization", organization, exceptions.InvalidOrganizationException)
-    organizations = serializers.serialize_organizations(internal.Organization.objects.filter(active=True))
+    organizations = serializers.serialize_organizations(
+        internal.Organization.objects.filter(id=organization_id, active=True)
+    )
     if not organizations:
         exceptions.raise_exception("organization", organization, exceptions.InvalidOrganizationException)
     return organizations[0]

--- a/organizations/tests/test_data.py
+++ b/organizations/tests/test_data.py
@@ -6,6 +6,8 @@ Note: 'Unit Test: ' labels are output to the console during test runs
 import organizations.data as data
 import organizations.tests.utils as utils
 
+from organizations.tests.factories import OrganizationFactory
+
 
 class OrganizationsDataTestCase(utils.OrganizationsTestCaseBase):
     """
@@ -22,3 +24,11 @@ class OrganizationsDataTestCase(utils.OrganizationsTestCaseBase):
                 'description': 'Local Organization Description'
             })
         self.assertGreater(organization['id'], 0)
+
+    def test_fetch_organization(self):
+        """ Unit Test: test_fetch_organization"""
+        organization1 = OrganizationFactory.create()
+        organization2 = OrganizationFactory.create()
+        with self.assertNumQueries(2):
+            self.assertEqual(data.fetch_organization(organization1.id)['id'], organization1.id)
+            self.assertEqual(data.fetch_organization(organization2.id)['id'], organization2.id)


### PR DESCRIPTION
This fixes a bug which was causing the get_organization function
to return the same organization every time. The issue was that we
were not using the given organization ID to filter the Django
queryset.

ENT-585