### PR TITLE
Add explicit 'fields' attribute to OrganizationSerializer.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ Zia Fazal <zfazal@edx.org>
 Ahsan Ulhaq <ahsan.ulhaq84@gmail.com>
 Christina Roberts <christina@edx.org>
 Douglas Hall <dhall@edx.org>
+Waheed Ahmed <waheed.ahmed@arbisoft.com>

--- a/organizations/__init__.py
+++ b/organizations/__init__.py
@@ -1,4 +1,4 @@
 """
 edx-organizations app initialization module
 """
-__version__ = '0.4.6'  # pragma: no cover
+__version__ = '0.4.7'  # pragma: no cover

--- a/organizations/serializers.py
+++ b/organizations/serializers.py
@@ -12,6 +12,7 @@ class OrganizationSerializer(serializers.ModelSerializer):
     """ Serializes the Organization object."""
     class Meta(object):  # pylint: disable=missing-docstring
         model = models.Organization
+        fields = '__all__'
 
 
 def serialize_organization(organization):


### PR DESCRIPTION
Creating a ModelSerializer without either the 'fields' attribute or the 'exclude'
attribute has been deprecated since 3.3.0.

LEARNER-2320