### PR TITLE
EDUCATOR-1913 Allow period(.) in organization's short name field

### DIFF
--- a/organizations/migrations/0006_auto_20171207_0259.py
+++ b/organizations/migrations/0006_auto_20171207_0259.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('organizations', '0005_auto_20171116_0640'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='organization',
+            name='short_name',
+            field=models.CharField(help_text='Please do not use spaces or special characters. Only allowed special characters are period (.), hyphen (-) and underscore (_).', max_length=255, verbose_name=b'Short Name', db_index=True),
+        ),
+    ]

--- a/organizations/models.py
+++ b/organizations/models.py
@@ -20,8 +20,8 @@ class Organization(TimeStampedModel):
     name = models.CharField(max_length=255, db_index=True)
     short_name = models.CharField(
         max_length=255, db_index=True, verbose_name='Short Name',
-        help_text=_("Please do not use any spaces or special characters in short name. "
-                    "This short name will be used in the course's course key.")
+        help_text=_('Please do not use spaces or special characters. Only allowed special characters '
+                    'are period (.), hyphen (-) and underscore (_).')
     )
     description = models.TextField(null=True, blank=True)
     logo = models.ImageField(
@@ -35,8 +35,10 @@ class Organization(TimeStampedModel):
         return u"{name} ({short_name})".format(name=self.name, short_name=self.short_name)
 
     def clean(self):
-        if not re.match("^[a-zA-Z0-9_-]*$", self.short_name):
-            raise ValidationError(_('Please do not use any spaces or special characters in the short name field'))
+        if not re.match("^[a-zA-Z0-9._-]*$", self.short_name):
+            raise ValidationError(_('Please do not use spaces or special characters in the short name '
+                                    'field. Only allowed special characters are period (.), hyphen (-) '
+                                    'and underscore (_).'))
 
 
 class OrganizationCourse(TimeStampedModel):

--- a/organizations/tests/test_models.py
+++ b/organizations/tests/test_models.py
@@ -17,26 +17,24 @@ class TestOrganizationModel(TestCase):
         self.organization = OrganizationFactory.create()
 
     @ddt.data(
-        "short name with space",
-        "short_name[with,special",
-        "shórt_name"
+        [" ", ",", "@", "(", "!", "#", "$", "%", "^", "&", "*", "+", "=", "{", "[", "ó"]
     )
-    def test_clean_error(self, short_name):
+    def test_clean_error(self, invalid_char_list):
         """
         Verify that the clean method raises validation error if org short name
         consists of special characters or spaces.
         """
-        self.organization.short_name = short_name
-        self.assertRaises(ValidationError, self.organization.clean)
+        for char in invalid_char_list:
+            self.organization.short_name = 'shortname{}'.format(char)
+            self.assertRaises(ValidationError, self.organization.clean)
 
     @ddt.data(
-        "shortnamewithoutspace",
-        "shortName123",
-        "short_name"
+        ["shortnamewithoutspace", "shortName123", "short_name", "short-name", "short.name"]
     )
-    def test_clean_success(self, short_name):
+    def test_clean_success(self, valid_short_name_list):
         """
         Verify that the clean method returns None if org short name is valid
         """
-        self.organization.short_name = short_name
-        self.assertEqual(self.organization.clean(), None)
+        for valid_short_name in valid_short_name_list:
+            self.organization.short_name = valid_short_name
+            self.assertEqual(self.organization.clean(), None)


### PR DESCRIPTION
# [EDUCATOR-1913](https://openedx.atlassian.net/browse/EDUCATOR-1913)

### Description
This PR allows [.] in organization's short name (In addition to alphanumeric characters, underscore and hyphen) to keep it consistent with studio and publisher.


### Testing
- [x] Unit test


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @awaisdar001 
- [x] Code review: @noraiz-anwar 

### Post-review
- [x] Rebase and squash commits

