### PR TITLE
PLAT-2061 Raise upper constraint on DRF version

### DIFF
--- a/organizations/__init__.py
+++ b/organizations/__init__.py
@@ -1,4 +1,4 @@
 """
 edx-organizations app initialization module
 """
-__version__ = '0.4.9'  # pragma: no cover
+__version__ = '0.4.10'  # pragma: no cover

--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,10 @@ setup(
     install_requires=[
         'django>=1.8,<2.0',
         'django-model-utils>=1.4.0',
-        'djangorestframework>=3.2.0,<3.4.0',
+        'djangorestframework>=3.2.0,<3.7.0',
         'djangorestframework-oauth>=1.1.0,<2.0.0',
         'edx-django-oauth2-provider>=1.2.0',
-        'edx-drf-extensions>=0.5.1,<1.0.0',
+        'edx-drf-extensions>=0.5.1',
         'edx-opaque-keys>=0.1.2,<1.0.0',
         'Pillow',
     ],


### PR DESCRIPTION
We're already using djangorestframework 3.6.3 with this in edx-platform, so the constraint seems too restrictive (and is preventing pip-compile from finding a version that satisfies all constraints).  Update to match the current upper limits in django-config-models and edx-proctoring.

Similarly, we're already using edx-drf-extensions 1.2.4 in edx-platform, so the upper limit on that is inappropriate as well.