### PR TITLE
Prepare for a package release.

### DIFF
--- a/organizations/__init__.py
+++ b/organizations/__init__.py
@@ -1,4 +1,4 @@
 """
 edx-organizations app initialization module
 """
-__version__ = '1.0.1'  # pragma: no cover
+__version__ = '2.0.1'  # pragma: no cover


### PR DESCRIPTION
Doing this as a major version upgrade because we were previously pinning
the djangorestframework library.  If upstream projects were relying on
us pinning it to stick to a specific version, our change might break
them.