### PR TITLE
Management command for adding organizations

### DIFF
--- a/organizations/__init__.py
+++ b/organizations/__init__.py
@@ -1,4 +1,4 @@
 """
 edx-organizations app initialization module
 """
-__version__ = '2.0.3'  # pragma: no cover
+__version__ = '2.1.0'  # pragma: no cover

--- a/organizations/data.py
+++ b/organizations/data.py
@@ -50,26 +50,26 @@ def _inactivate_record(record):
     record.save()
 
 
-def _activate_organization(organization):
+def _activate_organization(organization_id):
     """
     Activates an inactivated (soft-deleted) organization as well as any inactive relationships
     """
     [_activate_organization_course_relationship(record) for record
-     in internal.OrganizationCourse.objects.filter(organization_id=organization.id, active=False)]
+     in internal.OrganizationCourse.objects.filter(organization_id=organization_id, active=False)]
 
     [_activate_record(record) for record
-     in internal.Organization.objects.filter(id=organization.id, active=False)]
+     in internal.Organization.objects.filter(id=organization_id, active=False)]
 
 
-def _inactivate_organization(organization):
+def _inactivate_organization(organization_id):
     """
     Inactivates an activated organization as well as any active relationships
     """
     [_inactivate_organization_course_relationship(record) for record
-     in internal.OrganizationCourse.objects.filter(organization_id=organization.id, active=True)]
+     in internal.OrganizationCourse.objects.filter(organization_id=organization_id, active=True)]
 
     [_inactivate_record(record) for record
-     in internal.Organization.objects.filter(id=organization.id, active=True)]
+     in internal.Organization.objects.filter(id=organization_id, active=True)]
 
 
 def _activate_organization_course_relationship(relationship):  # pylint: disable=invalid-name
@@ -116,7 +116,7 @@ def create_organization(organization):
         )
         # If the organization exists, but was inactivated, we can simply turn it back on
         if not organization.active:
-            _activate_organization(organization_obj)
+            _activate_organization(organization.id)
     except internal.Organization.DoesNotExist:
         organization = internal.Organization.objects.create(
             name=organization_obj.name,
@@ -152,7 +152,7 @@ def delete_organization(organization):
     No return currently defined for this operation
     """
     organization_obj = serializers.deserialize_organization(organization)
-    _inactivate_organization(organization_obj)
+    _inactivate_organization(organization_obj.id)
 
 
 def fetch_organization(organization_id):

--- a/organizations/management/commands/add_organization.py
+++ b/organizations/management/commands/add_organization.py
@@ -1,0 +1,42 @@
+"""
+Add an organization through manage.py.
+"""
+import logging
+
+from django.core.management import BaseCommand, CommandError
+
+from organizations import api
+
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """Management command used to add an organization.
+
+    Example: ./manage.py add_organization hogwarts "Hogwarts School of Witchcraft and Wizardry"
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument('short_name')
+        parser.add_argument('name')
+
+    def handle(self, *args, **options):
+        org_options = {
+            key: options[key] for key in {'short_name', 'name'}
+        }
+
+        if len(org_options['short_name']) > len(org_options['name']):
+            fmt = (
+                "The provided short_name ({short_name}) "
+                "is longer than the provided name ({name}). "
+                "You probably want to switch the order of the arguments."
+            )
+            raise CommandError(fmt.format(**org_options))
+
+        created_org = api.add_organization(org_options)
+        log_fmt = (
+            "Created or activated organization: id={id}, "
+            "short_name={short_name}, name='{name}'"
+        )
+        logger.info(log_fmt.format(**created_org))

--- a/organizations/management/commands/tests/test_add_organization.py
+++ b/organizations/management/commands/tests/test_add_organization.py
@@ -1,0 +1,44 @@
+"""
+Tests for organization-adding management command.
+"""
+from django.core.management import call_command, CommandError
+from django.test import TestCase
+
+from organizations.models import Organization
+
+
+class TestAddOrganizationCommand(TestCase):
+    """ Tests for add_organization.Command. """
+
+    ORG_SHORT_NAME = "msw"
+    ORG_NAME = "Ministry of Silly Walks"
+
+    def assert_one_active_organization(self, short_name, name):
+        """
+        Assert that there is exactly one organization with the given short_name,
+        and if so, that it has the specified name and is active.
+        """
+        # Fails with MultipleObjectsReturned if >1 orgs matching `short_name`
+        org = Organization.objects.get(short_name=short_name)
+        self.assertEqual(org.name, name)
+        self.assertTrue(org.active)
+
+    def test_add_org(self):
+        call_command('add_organization', self.ORG_SHORT_NAME, self.ORG_NAME)
+        self.assert_one_active_organization(self.ORG_SHORT_NAME, self.ORG_NAME)
+
+    def test_add_same_org_twice(self):
+        call_command('add_organization', self.ORG_SHORT_NAME, self.ORG_NAME)
+        call_command('add_organization', self.ORG_SHORT_NAME, self.ORG_NAME)
+        self.assert_one_active_organization(self.ORG_SHORT_NAME, self.ORG_NAME)
+
+    def test_add_existing_org(self):
+        Organization.objects.create(
+            short_name=self.ORG_SHORT_NAME, name=self.ORG_NAME, active=False
+        )
+        call_command('add_organization', self.ORG_SHORT_NAME, self.ORG_NAME)
+        self.assert_one_active_organization(self.ORG_SHORT_NAME, self.ORG_NAME)
+
+    def test_bad_argument_order(self):
+        with self.assertRaises(CommandError):
+            call_command('add_organization', self.ORG_NAME, self.ORG_SHORT_NAME)

--- a/organizations/tests/test_api.py
+++ b/organizations/tests/test_api.py
@@ -43,7 +43,7 @@ class OrganizationsApiTestCase(utils.OrganizationsTestCaseBase):
             organization = api.add_organization(organization_data)
 
     def test_add_organization_inactive_to_active(self):
-        """ Unit Test: test_add_organization_inactive_organization_present"""
+        """ Unit Test: test_add_organization_inactive_to_active"""
         organization_data = {
             'name': 'local_organizationßßß',
             'description': 'Local Organization Descriptionßßß'
@@ -52,8 +52,12 @@ class OrganizationsApiTestCase(utils.OrganizationsTestCaseBase):
         self.assertGreater(organization['id'], 0)
         api.remove_organization(organization['id'])
 
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(5):
             organization = api.add_organization(organization_data)
+
+        # Assert that the organization is active by making sure we can load it.
+        loaded_organization = api.get_organization(organization['id'])
+        self.assertEqual(loaded_organization['name'], organization_data['name'])
 
     def test_add_organization_inactive_organization_with_relationships(self):
         """ Unit Test: test_add_organization_inactive_organization_with_relationships"""


### PR DESCRIPTION
@edx/masters-neem 
https://openedx.atlassian.net/browse/EDUCATOR-4495

Creates command that is called by https://github.com/edx/configuration/pull/5292

Also fixes a library bug where if you call `api.add_organization` with a duplicate name, it is supposed to just activate the organization, but instead it does nothing.