### PR TITLE
Changing prefix from b to u in migration files to fix type mismatch

### DIFF
--- a/organizations/migrations/0001_initial.py
+++ b/organizations/migrations/0001_initial.py
@@ -18,10 +18,10 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('created', model_utils.fields.AutoCreatedField(default=django.utils.timezone.now, verbose_name='created', editable=False)),
                 ('modified', model_utils.fields.AutoLastModifiedField(default=django.utils.timezone.now, verbose_name='modified', editable=False)),
-                ('name', models.CharField(max_length=255, verbose_name=b'Long name', db_index=True)),
+                ('name', models.CharField(max_length=255, verbose_name=u'Long name', db_index=True)),
                 ('short_name', models.CharField(max_length=255, db_index=True)),
                 ('description', models.TextField()),
-                ('logo', models.ImageField(help_text='Please add only .PNG files for logo images.', max_length=255, null=True, upload_to=b'organization_logos', blank=True)),
+                ('logo', models.ImageField(help_text='Please add only .PNG files for logo images.', max_length=255, null=True, upload_to=u'organization_logos', blank=True)),
                 ('active', models.BooleanField(default=True)),
             ],
             options={

--- a/organizations/migrations/0002_auto_20170117_1434.py
+++ b/organizations/migrations/0002_auto_20170117_1434.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='organization',
             name='logo',
-            field=models.ImageField(help_text='Please add only .PNG files for logo images. This logo will be used on certificates.', max_length=255, null=True, upload_to=b'organization_logos', blank=True),
+            field=models.ImageField(help_text='Please add only .PNG files for logo images. This logo will be used on certificates.', max_length=255, null=True, upload_to=u'organization_logos', blank=True),
         ),
     ]

--- a/organizations/migrations/0004_auto_20170413_2315.py
+++ b/organizations/migrations/0004_auto_20170413_2315.py
@@ -14,11 +14,11 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='organization',
             name='short_name',
-            field=models.CharField(max_length=255, verbose_name=b'Short Name', db_index=True),
+            field=models.CharField(max_length=255, verbose_name=u'Short Name', db_index=True),
         ),
         migrations.AlterField(
             model_name='organizationcourse',
             name='course_id',
-            field=models.CharField(max_length=255, verbose_name=b'Course ID', db_index=True),
+            field=models.CharField(max_length=255, verbose_name=u'Course ID', db_index=True),
         ),
     ]

--- a/organizations/migrations/0005_auto_20171116_0640.py
+++ b/organizations/migrations/0005_auto_20171116_0640.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='organization',
             name='short_name',
-            field=models.CharField(help_text="Please do not use any spaces or special characters in short name. This short name will be used in the course's course key.", max_length=255, verbose_name=b'Short Name', db_index=True),
+            field=models.CharField(help_text="Please do not use any spaces or special characters in short name. This short name will be used in the course's course key.", max_length=255, verbose_name=u'Short Name', db_index=True),
         ),
     ]

--- a/organizations/migrations/0006_auto_20171207_0259.py
+++ b/organizations/migrations/0006_auto_20171207_0259.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='organization',
             name='short_name',
-            field=models.CharField(help_text='Please do not use spaces or special characters. Only allowed special characters are period (.), hyphen (-) and underscore (_).', max_length=255, verbose_name=b'Short Name', db_index=True),
+            field=models.CharField(help_text='Please do not use spaces or special characters. Only allowed special characters are period (.), hyphen (-) and underscore (_).', max_length=255, verbose_name=u'Short Name', db_index=True),
         ),
     ]

--- a/organizations/migrations/0007_historicalorganization.py
+++ b/organizations/migrations/0007_historicalorganization.py
@@ -25,7 +25,7 @@ class Migration(migrations.Migration):
                 ('created', model_utils.fields.AutoCreatedField(default=django.utils.timezone.now, editable=False, verbose_name='created')),
                 ('modified', model_utils.fields.AutoLastModifiedField(default=django.utils.timezone.now, editable=False, verbose_name='modified')),
                 ('name', models.CharField(db_index=True, max_length=255)),
-                ('short_name', models.CharField(db_index=True, help_text='Please do not use spaces or special characters. Only allowed special characters are period (.), hyphen (-) and underscore (_).', max_length=255, verbose_name=b'Short Name')),
+                ('short_name', models.CharField(db_index=True, help_text='Please do not use spaces or special characters. Only allowed special characters are period (.), hyphen (-) and underscore (_).', max_length=255, verbose_name=u'Short Name')),
                 ('description', models.TextField(blank=True, null=True)),
                 ('logo', models.TextField(blank=True, help_text='Please add only .PNG files for logo images. This logo will be used on certificates.', max_length=255, null=True)),
                 ('active', models.BooleanField(default=True)),

--- a/organizations/models.py
+++ b/organizations/models.py
@@ -22,13 +22,13 @@ class Organization(TimeStampedModel):
     """
     name = models.CharField(max_length=255, db_index=True)
     short_name = models.CharField(
-        max_length=255, db_index=True, verbose_name='Short Name',
+        max_length=255, db_index=True, verbose_name=u'Short Name',
         help_text=_('Please do not use spaces or special characters. Only allowed special characters '
                     'are period (.), hyphen (-) and underscore (_).')
     )
     description = models.TextField(null=True, blank=True)
     logo = models.ImageField(
-        upload_to='organization_logos',
+        upload_to=u'organization_logos',
         help_text=_('Please add only .PNG files for logo images. This logo will be used on certificates.'),
         null=True, blank=True, max_length=255
     )
@@ -53,7 +53,7 @@ class OrganizationCourse(TimeStampedModel):
     (in the Django/ORM sense) the modeling and integrity is limited to that
     of specifying course identifier strings in this model.
     """
-    course_id = models.CharField(max_length=255, db_index=True, verbose_name='Course ID')
+    course_id = models.CharField(max_length=255, db_index=True, verbose_name=u'Course ID')
     organization = models.ForeignKey(Organization, db_index=True, on_delete=models.CASCADE)
     active = models.BooleanField(default=True)
 


### PR DESCRIPTION
The 'b' prefix before strings in migration files causes issues in python3. This replaces 'b' prefix with 'u' in migration files and adds 'u' prefix in relevant places in model.py
	- this should not cause any issues in python 2