### PR TITLE
Pin drf-jwt to 1.15.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,15 +5,13 @@
 #    make upgrade
 #
 certifi==2020.6.20        # via requests
-cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via requests
-cryptography==2.9.2       # via pyjwt
 django-model-utils==4.0.0  # via -r requirements/base.in
 django-simple-history==2.11.0  # via -r requirements/base.in
 django-waffle==1.0.0      # via edx-django-utils, edx-drf-extensions
 django==2.2.14            # via -c requirements/constraints.txt, -r requirements/base.in, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, rest-condition
 djangorestframework==3.11.0  # via -r requirements/base.in, drf-jwt, edx-drf-extensions, rest-condition
-drf-jwt==1.16.2           # via edx-drf-extensions
+drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
 edx-django-utils==3.2.3   # via edx-drf-extensions
 edx-drf-extensions==6.1.0  # via -r requirements/base.in
 edx-opaque-keys==2.1.0    # via -r requirements/base.in, edx-drf-extensions
@@ -23,17 +21,16 @@ newrelic==5.14.1.144      # via edx-django-utils
 pbr==5.4.5                # via stevedore
 pillow==7.2.0             # via -r requirements/base.in
 psutil==1.2.1             # via edx-django-utils
-pycparser==2.20           # via cffi
 pycryptodomex==3.9.8      # via pyjwkest
 pyjwkest==1.4.2           # via edx-drf-extensions
-pyjwt[crypto]==1.7.1      # via drf-jwt
+pyjwt==1.7.1              # via drf-jwt
 pymongo==3.10.1           # via edx-opaque-keys
 python-dateutil==2.8.1    # via edx-drf-extensions
 pytz==2020.1              # via django
 requests==2.24.0          # via edx-drf-extensions, pyjwkest
 rest-condition==1.0.3     # via edx-drf-extensions
 semantic-version==2.8.5   # via edx-drf-extensions
-six==1.15.0               # via cryptography, django-simple-history, edx-drf-extensions, edx-opaque-keys, pyjwkest, python-dateutil, stevedore
+six==1.15.0               # via django-simple-history, edx-drf-extensions, edx-opaque-keys, pyjwkest, python-dateutil, stevedore
 sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys
 urllib3==1.25.9           # via requests

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,3 +10,7 @@
 
 # Stay on an LTS release
 django<2.3
+
+# latest version drf-jwt==1.16.2 is causing failures in ecom, platform and discovery. 
+# So avoiding that until fix that issue.
+drf-jwt<1.15.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,19 +8,17 @@ appdirs==1.4.4            # via virtualenv
 astroid==2.3.3            # via pylint, pylint-celery
 attrs==19.3.0             # via pytest
 certifi==2020.6.20        # via -r requirements/base.txt, requests
-cffi==1.14.0              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
 coverage==5.2             # via -r requirements/test.in, pytest-cov
-cryptography==2.9.2       # via -r requirements/base.txt, pyjwt
 ddt==1.4.1                # via -r requirements/test.in
 distlib==0.3.1            # via virtualenv
 django-model-utils==4.0.0  # via -r requirements/base.txt
 django-simple-history==2.11.0  # via -r requirements/base.txt
 django-waffle==1.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 djangorestframework==3.11.0  # via -r requirements/base.txt, drf-jwt, edx-drf-extensions, rest-condition
-drf-jwt==1.16.2           # via -r requirements/base.txt, edx-drf-extensions
+drf-jwt==1.14.0           # via -c requirements/constraints.txt, -r requirements/base.txt, edx-drf-extensions
 edx-django-utils==3.2.3   # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==6.1.0  # via -r requirements/base.txt
 edx-lint==1.5.0           # via -r requirements/test.in
@@ -46,10 +44,9 @@ pluggy==0.13.1            # via pytest, tox
 psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils
 py==1.9.0                 # via pytest, tox
 pycodestyle==2.6.0        # via -r requirements/test.in
-pycparser==2.20           # via -r requirements/base.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/base.txt, pyjwkest
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
-pyjwt[crypto]==1.7.1      # via -r requirements/base.txt, drf-jwt
+pyjwt==1.7.1              # via -r requirements/base.txt, drf-jwt
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
@@ -64,7 +61,7 @@ pytz==2020.1              # via -r requirements/base.txt, django
 requests==2.24.0          # via -r requirements/base.txt, edx-drf-extensions, pyjwkest
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
-six==1.15.0               # via -r requirements/base.txt, astroid, cryptography, django-simple-history, edx-drf-extensions, edx-lint, edx-opaque-keys, httpretty, packaging, pathlib2, pyjwkest, python-dateutil, stevedore, tox, virtualenv
+six==1.15.0               # via -r requirements/base.txt, astroid, django-simple-history, edx-drf-extensions, edx-lint, edx-opaque-keys, httpretty, packaging, pathlib2, pyjwkest, python-dateutil, stevedore, tox, virtualenv
 sqlparse==0.3.1           # via -r requirements/base.txt, django
 stevedore==1.32.0         # via -r requirements/base.txt, edx-opaque-keys
 text-unidecode==1.3       # via faker
@@ -72,7 +69,7 @@ toml==0.10.1              # via tox
 tox==3.16.1               # via -r requirements/test.in
 typed-ast==1.4.1          # via astroid
 urllib3==1.25.9           # via -r requirements/base.txt, requests
-virtualenv==20.0.25       # via tox
+virtualenv==20.0.26       # via tox
 wcwidth==0.2.5            # via pytest
 wrapt==1.11.2             # via astroid
 zipp==1.2.0               # via importlib-metadata, importlib-resources


### PR DESCRIPTION
Latest version drf-jwt==1.16.2 is causing failures in ecom, platform and discovery. 
So avoiding that until fix that issue.
