### PR TITLE
[BD-14] Adjust API for global phase-in of database-backed orgs with optional strictness

### DIFF
--- a/docs/decisions/0001-phase-in-db-backed-organizations-to-all.rst
+++ b/docs/decisions/0001-phase-in-db-backed-organizations-to-all.rst
@@ -1,0 +1,202 @@
+1. Phase In Database-Backed Organizations to All Open edX Installations
+=======================================================================
+
+Status
+------
+
+Accepted
+
+Context
+-------
+
+Why edx-organizations exists
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Originally, the concepts of "organizations" and "courses associated with organizations"
+were implicit in edx-platform, being inferred from the "org" part of course/library
+keys. For example, in ``course-v1:edX+DemoX+2020``, ``edX`` is the inferred organization.
+There are numerous drawbacks to this being the only mechanism by which organizations exist.
+Notably:
+
+1. Efficient filtering, searching, and sorting on organization association is
+   complicated, as enumerating organizations involves a full scan of all course runs
+   and/or content libraries in the system.
+2. Validating that course runs' "org" references point to real, intentionally-
+   specified organizations is impossible. We cannot catch typos in "org" references.
+3. We cannot use database-level joins to implement concepts like organization-derived
+   access control.
+
+This package was created to formalize the organization concept at a database level,
+addressing the aformentioned issues.
+It does so by introducing two models:
+
+* ``Organization``, which describes an school, insitution, or other such organization.
+  In edx-platform, instances are added via Django Admin or management command.
+* ``OrganizationCourse``, a many-to-many join between organizations and course runs.
+  In edx-platform, instances are automatically created when new course runs are created.
+
+To ensure backwards compatibility, the installation of this packages as a Django app in
+edx-platform is behind the ``FEATURES['ORGANIZATIONS_APP']`` flag, which defaults to
+``False``. **Unless** that flag is specifically enabled:
+
+* the ``Organization`` and ``OrganizationCourse`` models are unavailable,
+* the functions in ``util.organizations_helpers`` (which edx-platform uses to wrap
+  ``organizations.api``) will short-circuit and return ``[]`` or ``None`` for all calls, and
+* validation of the "org" references when creating course runs is disabled.
+
+Why we want to enable edx-organizations globally
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Although the organizations app is enabled on edx.org and stage.edx.org,
+it is **not** enabled by default for Open edX installations. Notably, it is disabled
+on edge.edx.org, which has 10,000+ course runs and 1,000+ content libraries.
+Critically, this means that when writing edx-platform features,
+we cannot assume that database-backed organizations will be available,
+forcing us to write features that either:
+
+* fall back to reasonable behavior when the organizations app is disabled, or
+* put said feature behind a flag, whose enabling is dependent upon the organization app
+  also being enabled.
+
+These considerations add complexity to edx-platform feature development and roll-out.
+In particular, the Blockstore-Powered Content Libraries and Taxonomies project
+(a.k.a. `BD-14`_) aims to develop a new model of Blockstore-based
+content libraries, which foreign-keys to the ``Organization`` model to enable
+organization-based authorization and easier searching/filtering.
+Making this new code tolerate the absence of database-backed organizations would require
+refactoring that does not strike us as worthwhile or especially desirable.
+However, we still hope to roll these new content libraries out to all Open edX instances,
+including ones where the organizations app is currently disabled.
+
+So, given all of this, **we would like to enable database-backed organizations across all Open edX
+instances.**
+
+Why that isn't simple
+~~~~~~~~~~~~~~~~~~~~~
+
+However, there is one particular aspect of enabling the organizations app
+in edx-platform that would be a breaking change to anyone who does not already
+enable the organizations app: **org validation**.
+When ``FEATURES['ORGANIZATIONS_APP'] == True``, course runs created through
+Studio must have a course key with an "org" part that maps to an organization in the
+database. If one were to enable the organizations app for an instance that previously
+had it disabled, then a backfill of their ``Organization`` table would need to be performed
+before course runs could be created in Studio as before.
+
+
+.. _BD-14: https://openedx.atlassian.net/wiki/spaces/COMM/pages/1545011241/BD-14+Blockstore+Powered+Content+Libraries+Taxonomies
+
+Decision
+--------
+
+We want to enable database-backed organizations in edx-platform for all Open edX
+instances, without an ability to disable them.
+However, we do not want to force organization validation upon all Open edX instances.
+So, we will **install the organizations app by default** but also
+**auto-create organizations** for new course runs and libraries by default.
+
+The organization validation behavior will only take effect when
+organization auto-creation is explicitly disabled.
+
+Finally, we will provide an **organization backfill management command**
+to auto-create all missing organizations and organization-course linkages.
+We will instruct operators to run it as part of the Koa upgrade.
+
+
+Consequences
+------------
+
+Overview
+~~~~~~~~
+
+The ``organizations`` app will be installed in edx-platform for all Open edX instances. This will simplify the roll-out of BD-14 and other projects that depend on database-backed organizations.
+
+The dichotomy between the behaviors of **auto-creating missing organizations**
+and **validating against missing organizations** will be toggled by a new Django flag:
+``ORGANIZATIONS_AUTOCREATE``.
+
+When ``True`` ("auto-create mode", default), the ``Organization`` model will be
+treated as a **downstream source** of data for LMS/Studio, so creating content that
+references a non-existant organization should cause that organization to be
+automatically created in the database.
+
+When ``False`` ("validate mode"), the ``Organization`` model will be
+treated as an **authoritative source** of data for LMS/Studio,
+so creating content that references
+a non-existant organization should result in a validation error.
+
+
+In this package (edx-organizations)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Four new Python API functions will be added:
+
+* ``is_autocreation_enabled``: Tests and returns ``ORGANIZATIONS_AUTOCREATE``,
+  as set in the Django settings of the project that installs edx-organizations
+  (generally, edx-platform). Also checks ``not FEATURES["ORGANIZATIONS_APP"]`` for
+  backwards-compatibility. Defaults to ``True``.
+* ``ensure_organization``: Given an organization's short name, try to fetch that
+  organization's details. If it does not exist, then either raise an exception
+  ("auto-create mode") or create a new organization ("validate mode").
+* ``get_course_organization[_id]``: Get the first organization that a course was linked
+  to. This addition is tangential, but it allows us to finish ripping out
+  the ``organizations_helpers`` wrapper layer that edx-platform had put around edx-organizations.
+
+The package vesion will be bumped from 5.2.0 to 5.3.0. It is a minor version bump to signify
+the lack of breaking changes.
+
+These changes will be made in `pull request 137`_.
+
+.. _pull request 137: https://github.com/edx/edx-organizations/pull/137
+
+After one edx-platform release, Version 6.0.0 of this package can be released,
+which would remove the now-unnecessary check for ``FEATURES["ORGANIZATIONS_APP"]``.
+
+In edx-platform
+~~~~~~~~~~~~~~~
+
+``organizations`` will be installed into LMS and Studio as a default app instead of as an optional app.
+
+A management command will be added to backfill the
+``Organization`` and ``OrganizationCourse`` table based on the course runs and content
+libraries in the system.
+
+The ``ORGANIZATIONS_AUTOCREATE`` toggle will be added to ``cms/envs/common.py`` with
+a default value of ``True``.
+
+The ``FEATURES["ORGANIATIONS_APP"]`` toggle will be removed.
+
+The new ``organizations.api.ensure_organization`` function will be used to either
+auto-create or raise when organizations are missing during course run and
+content library creation.
+
+The ``util.organizations_helpers`` module, which wrapped ``organizations.api``
+functions to support the app's optionality, will be completely removed, and all
+references will be updated to use ``organizations.api`` directly.
+
+These changes will be made in `pull request 25153`_.
+
+.. _pull request 25153: https://github.com/edx/edx-platform/pull/25153
+
+Community
+~~~~~~~~~
+
+The community will be informed of the change via both Discourse and the release notes for Koa.
+Instructions for migration will be included.
+
+`DEPR-117`_ is created to track the eventual removal of the ``FEATURES["ORGANIATIONS_APP"]``,
+ideally in Lilac.
+
+.. _DEPR-117: https://openedx.atlassian.net/browse/DEPR-117
+
+edX Ops
+~~~~~~~
+
+With the help of SRE, the organizations backfill will be run for edge.edx.org.
+
+For edx.org and stage.edx.org, the ``FEATURES["ORGANIATIONS_APP"] = True``
+overrides will be updated to be ``ORGANIZATIONS_AUTOCREATE = False``
+in `pull request 3456`_.
+
+.. _pull request 3456: https://github.com/edx/edx-internal/pull/3456
+

--- a/organizations/__init__.py
+++ b/organizations/__init__.py
@@ -1,4 +1,4 @@
 """
 edx-organizations app initialization module
 """
-__version__ = '5.2.0'  # pragma: no cover
+__version__ = '5.3.0'  # pragma: no cover

--- a/organizations/models.py
+++ b/organizations/models.py
@@ -7,13 +7,11 @@ offers one programmatic API -- api.py for direct Python integration.
 import re
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from model_utils.models import TimeStampedModel
 from simple_history.models import HistoricalRecords
 
 
-@python_2_unicode_compatible
 class Organization(TimeStampedModel):
     """
     An Organization is a representation of an entity which publishes/provides

--- a/organizations/tests/test_api.py
+++ b/organizations/tests/test_api.py
@@ -2,6 +2,9 @@
 """
 Organizations API Module Test Cases
 """
+from unittest.mock import patch
+
+from django.test import override_settings
 
 import organizations.api as api
 import organizations.exceptions as exceptions
@@ -249,6 +252,40 @@ class OrganizationsApiTestCase(utils.OrganizationsTestCaseBase):
             course_organizations = api.get_course_organizations(self.test_course_key)
         self.assertEqual(len(course_organizations), 1)
 
+    def test_get_course_organization_no_linked_orgs(self):
+        """
+        Test that when a course is linked to no organizations,
+        ``get_course_organization`` and ``get_course_organization_id`` return None.
+        """
+        assert api.get_course_organization(self.test_course_key) is None
+        assert api.get_course_organization_id(self.test_course_key) is None
+
+    def test_get_course_organization_multi_linked_orgs(self):
+        """
+        Test that when a course is linked to multiple organizations,
+        ``get_course_organization`` and ``get_course_organization_id``
+        return the first-linked one.
+        """
+        # Use non-alphabetically-ordered org names to test that the
+        # returned org was the first *linked*, not just the first *alphabetically*.
+        api.add_organization_course(
+            api.add_organization({'short_name': 'orgW', 'name': 'Org West'}),
+            self.test_course_key,
+        )
+        api.add_organization_course(
+            api.add_organization({'short_name': 'orgN', 'name': 'Org North'}),
+            self.test_course_key,
+        )
+        api.add_organization_course(
+            api.add_organization({'short_name': 'orgS', 'name': 'Org South'}),
+            self.test_course_key,
+        )
+        org_result = api.get_course_organization(self.test_course_key)
+        assert org_result['short_name'] == 'orgW'
+        org_id_result = api.get_course_organization_id(self.test_course_key)
+        assert org_id_result
+        assert org_id_result == org_result['id']
+
     def test_remove_organization_course(self):
         """ Unit Test: test_remove_organization_course """
         api.add_organization_course(
@@ -295,3 +332,85 @@ class OrganizationsApiTestCase(utils.OrganizationsTestCaseBase):
         with self.assertNumQueries(2):
             api.remove_course_references(self.test_course_key)
         self.assertEqual(len(api.get_organization_courses(self.test_organization)), 0)
+
+    @patch.object(api.log, 'info')
+    def test_ensure_organization_retrieves_known_org(self, mock_log_info):
+        """
+        Test that, with oranization auto-create enabled, ``ensure_organization``
+        returns the org data of an existing organization.
+        """
+        api.add_organization({
+            'short_name': 'myorg', 'name': 'My Org', 'description': 'this is my org'
+        })
+        org_data = api.ensure_organization('myorg')
+        assert org_data['id']
+        assert org_data['short_name'] == 'myorg'
+        assert org_data['name'] == 'My Org'
+        assert org_data['description'] == 'this is my org'
+
+        # We expect a single logging message in test_ensure_organization_creates_unknown_org,
+        # so check for 0 log messages here as a control.
+        assert mock_log_info.call_count == 0
+
+    @patch.object(api.log, 'info')
+    def test_ensure_organization_creates_unknown_org(self, mock_log_info):
+        """
+        Test that, with organization auto-create enabled, ``ensure_organization``
+        automatically creates not-yet-existent organizations.
+        """
+        org_data = api.ensure_organization('myorg')
+        assert org_data['id']
+        assert org_data['short_name'] == 'myorg'
+        assert org_data['name'] == 'myorg'
+        assert org_data['description'] == ''  # auto-created, so no description.
+
+        # Make sure we logged about the new organization's creation.
+        assert mock_log_info.call_count == 1
+
+        # Make sure that the organization has, in fact, been saved to the database
+        # by loading it up again.
+        assert api.get_organization_by_short_name('myorg') == org_data
+
+    @override_settings(ORGANIZATIONS_AUTOCREATE=False)
+    def test_ensure_organization_retrieves_known_org_no_autocreate(self):
+        """
+        Test that, with organization auto-create DISABLED, ``ensure_organization``
+        returns the org data of an existing organization
+        (just like it does when organization auto-create is enabled).
+        """
+        api.add_organization({
+            'short_name': 'myorg', 'name': 'My Org', 'description': 'this is my org'
+        })
+        org_data = api.ensure_organization('myorg')
+        assert org_data['id']
+        assert org_data['short_name'] == 'myorg'
+        assert org_data['name'] == 'My Org'
+        assert org_data['description'] == 'this is my org'
+
+    @override_settings(ORGANIZATIONS_AUTOCREATE=False)
+    def test_ensure_organization_raises_for_unknown_org_no_autocreate(self):
+        """
+        Test that, with organization auto-create DISABLED, ``ensure_organization``
+        fails when given a non-existent organization
+        (in contrast to how it behaves when organization auto-create is enabled).
+        """
+        with self.assertRaises(exceptions.InvalidOrganizationException):
+            api.ensure_organization('myorg')
+
+        # Make sure the organization was not saved to the database.
+        with self.assertRaises(exceptions.InvalidOrganizationException):
+            api.get_organization_by_short_name('myorg')
+
+    def test_autocreate_enabled_by_default(self):
+        """
+        Test that, by default, automatic organization creation is enabled.
+        """
+        assert api.is_autocreate_enabled()
+
+    @override_settings(FEATURES={"ORGANIZATIONS_APP": True})
+    def test_autocreate_disabled_by_organizations_app(self):
+        """
+        Tests that enabling FEATURES['ORGANIZATIONS_APP'] has the effect of
+        disabling automatic organization creation.
+        """
+        assert not api.is_autocreate_enabled()

--- a/organizations/v0/tests/test_views.py
+++ b/organizations/v0/tests/test_views.py
@@ -100,7 +100,7 @@ class TestOrganizationsView(TestCase):
     def test_create_as_only_staff_user(self):
         self.user.is_staff = True
         self.user.is_superuser = False
-        self.user.save()  # pylint: disable=no-member
+        self.user.save()
 
         data = {
             'name': 'example-name',
@@ -113,7 +113,7 @@ class TestOrganizationsView(TestCase):
 
     def test_create_as_non_staff_and_non_admin_user(self):
         self.user.is_superuser = False
-        self.user.save()  # pylint: disable=no-member
+        self.user.save()
 
         data = {
             'name': 'example-name',


### PR DESCRIPTION
Implements part of [TNL-7425](https://openedx.atlassian.net/browse/TNL-7425).

Needed by https://github.com/edx/edx-platform/pull/25153

See the linked ADR for context.

Note: As I work on [the edx-platform side]( https://github.com/edx/edx-platform/pull/25153) of this ticket, I'm realizing I need to make [further API additions in this repo](https://github.com/edx/edx-organizations/pull/138), but those new additions shouldn't block review and merge of this.