### PR TITLE
[BD-14] Add bulk org/org-course creation for use in edx-platform backfill

### DIFF
--- a/organizations/__init__.py
+++ b/organizations/__init__.py
@@ -1,4 +1,4 @@
 """
 edx-organizations app initialization module
 """
-__version__ = '6.0.0'  # pragma: no cover
+__version__ = '6.1.0'  # pragma: no cover

--- a/organizations/admin.py
+++ b/organizations/admin.py
@@ -1,6 +1,6 @@
 """ Django admin pages for organization models """
 from django.contrib import admin
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from organizations.models import Organization, OrganizationCourse
 

--- a/organizations/models.py
+++ b/organizations/models.py
@@ -7,7 +7,7 @@ offers one programmatic API -- api.py for direct Python integration.
 import re
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from model_utils.models import TimeStampedModel
 from simple_history.models import HistoricalRecords
 

--- a/organizations/tests/utils.py
+++ b/organizations/tests/utils.py
@@ -17,3 +17,16 @@ class OrganizationsTestCaseBase(TestCase):
         """
         super(OrganizationsTestCaseBase, self).setUp()
         self.test_course_key = CourseKey.from_string('the/course/key')
+
+    @staticmethod
+    def make_organization_data(short_name):
+        """
+        Make a fake organization dictionary, distinguished by a `short_name`.
+
+        The `short_name` should be a valid short_name string, i.e. [0-9a-z_-].
+        """
+        return {
+            'short_name': short_name,
+            'name': "Name of {}".format(short_name),
+            'description': "Description of {}".format(short_name),
+        }

--- a/organizations/urls.py
+++ b/organizations/urls.py
@@ -1,9 +1,9 @@
 """
 URLS for organizations
 """
-from django.conf.urls import url, include
+from django.conf.urls import re_path, include
 
 app_name = 'organizations'  # pylint: disable=invalid-name
 urlpatterns = [
-    url(r'^v0/', include('organizations.v0.urls')),
+    re_path(r'^v0/', include('organizations.v0.urls')),
 ]


### PR DESCRIPTION
# Commits

## 1. Fix some trivial RemovedInDjango40Warnings
   
* Replace `ugettext` with `gettext`.
* Replace `url` with `re_path`.
    
 These are both no-ops; the old names were aliases.

## 2. Add API functions for bulk creation of orgs, org-courses
    
Adds two new functions to `organizations.api`

* `bulk_add_organizations`
* `bulk_add_organization_courses`

Both use Django's `bulk_create` and `bulk_update` functions to allow insertion of many rows in a constant number of queries.
    
This will aid in the upcoming edx-platform `backfill_orgs_and_org_courses` management command.

## 3. Bump version to 6.0.0 from 6.1.0

Some new API functions, but no breaking changes; thus, minor version bump.

# Links

Ticket: https://openedx.atlassian.net/browse/TNL-7645
Previous: https://github.com/edx/edx-organizations/pull/141
Next: https://github.com/edx/edx-platform/pull/25153