### PR TITLE
Add dry_run option to bulk-create functions

### DIFF
--- a/organizations/__init__.py
+++ b/organizations/__init__.py
@@ -1,4 +1,4 @@
 """
 edx-organizations app initialization module
 """
-__version__ = '6.1.0'  # pragma: no cover
+__version__ = '6.2.0'  # pragma: no cover

--- a/organizations/api.py
+++ b/organizations/api.py
@@ -51,7 +51,7 @@ def add_organization(organization_data):
     return organization
 
 
-def bulk_add_organizations(organization_data_items):
+def bulk_add_organizations(organization_data_items, dry_run=False):
     """
     Efficiently store multiple organizations.
 
@@ -78,6 +78,11 @@ def bulk_add_organizations(organization_data_items):
             If multiple organizations share a `short_name`, the first organization
             in `organization_data_items` will be used, and the latter ones ignored.
 
+        dry_run (bool):
+            Optional, defaulting to False.
+            If True, log organizations that would be created or activated,
+            but do not actually apply the changes to the database.
+
     Raises:
         InvalidOrganizationException: One or more organization dictionaries
             have missing or invalid data; no organizations were created.
@@ -88,7 +93,7 @@ def bulk_add_organizations(organization_data_items):
             raise exceptions.InvalidOrganizationException(
                 "Organization is missing short_name: {}".format(organization_data)
             )
-    data.bulk_create_organizations(organization_data_items)
+    data.bulk_create_organizations(organization_data_items, dry_run)
 
 
 def edit_organization(organization_data):
@@ -142,7 +147,7 @@ def add_organization_course(organization_data, course_key):
     )
 
 
-def bulk_add_organization_courses(organization_course_pairs):
+def bulk_add_organization_courses(organization_course_pairs, dry_run=False):
     """
     Efficiently store multiple organization-course relationships.
 
@@ -160,6 +165,11 @@ def bulk_add_organization_courses(organization_course_pairs):
 
             Assumption: All provided organizations already exist in storage.
 
+        dry_run (bool):
+            Optional, defaulting to False.
+            If True, log organizations-course linkages that would be created or
+            activated, but do not actually apply the changes to the database.
+
     Raises:
         InvalidOrganizationException: One or more organization dictionaries
             have missing or invalid data.
@@ -173,7 +183,7 @@ def bulk_add_organization_courses(organization_course_pairs):
                 "Organization is missing short_name: {}".format(organization_data)
             )
         _validate_course_key(course_key)
-    data.bulk_create_organization_courses(organization_course_pairs)
+    data.bulk_create_organization_courses(organization_course_pairs, dry_run)
 
 
 def get_organization_courses(organization_data):

--- a/organizations/data.py
+++ b/organizations/data.py
@@ -214,10 +214,12 @@ def bulk_create_organizations(organizations, dry_run=False):
         org.short_name for org in organizations_to_create
     ]
     log.info(
-        "Organizations to be bulk-reactivated (n=%i): %r. "
-        "Organizations to be bulk-created (n=%i): %r.",
+        "Organizations to be bulk-reactivated (n=%i): %r. ",
         len(short_names_of_organizations_to_reactivate),
         short_names_of_organizations_to_reactivate,
+    )
+    log.info(
+        "Organizations to be bulk-created (n=%i): %r.",
         len(short_names_of_organizations_to_create),
         short_names_of_organizations_to_create,
     )
@@ -393,12 +395,14 @@ def bulk_create_organization_courses(organization_course_pairs, dry_run=False):
     # Log what we're about to do.
     # If this is a dry run, return before applying any changes to the db.
     log.info(
-        "Organization-course linkages to be bulk-reactivated (n=%i): %r. "
-        "Organization-course linkages to be bulk-created (n=%i): %r.",
+        "Organization-course linkages to be bulk-reactivated (n=%i): %r. ",
         len(orgslug_courseid_pairs_to_reactivate),
-        orgslug_courseid_pairs_to_reactivate,
+        list(orgslug_courseid_pairs_to_reactivate),
+    )
+    log.info(
+        "Organization-course linkages to be bulk-created (n=%i): %r.",
         len(orgslug_courseid_pairs_to_create),
-        orgslug_courseid_pairs_to_create,
+        list(orgslug_courseid_pairs_to_create),
     )
     if dry_run:
         return

--- a/organizations/tests/test_api.py
+++ b/organizations/tests/test_api.py
@@ -651,8 +651,10 @@ class BulkAddOrganizationCoursesTestCase(utils.OrganizationsTestCaseBase):
         api.remove_organization_course(org_a, course_key_z)
 
         # 1 query to load list of existing org-courses,
-        # 1 query for activate-existing, and 1 query for create-new.
-        with self.assertNumQueries(3):
+        # 1 query to fetch related organizations,
+        # 1 query for activate-existing,
+        # 1 query for create-new.
+        with self.assertNumQueries(4):
             api.bulk_add_organization_courses([
 
                 # A->X: Existing linkage, should be a no-op.
@@ -712,8 +714,10 @@ class BulkAddOrganizationCoursesTestCase(utils.OrganizationsTestCaseBase):
         api.remove_organization_course(org_a, course_key_y)
 
         # 1 query to load list of existing org-courses,
-        # 1 query for activate-existing, and 1 query for create-new.
-        with self.assertNumQueries(3):
+        # 1 query to fetch related organizations,
+        # 1 query for activate-existing,
+        # 1 query for create-new.
+        with self.assertNumQueries(4):
             api.bulk_add_organization_courses([
                 (org_a, course_key_x),  # Already existing.
                 (org_a, course_key_x),  # Already existing.

--- a/organizations/tests/test_api.py
+++ b/organizations/tests/test_api.py
@@ -477,7 +477,8 @@ class BulkAddOrganizationsTestCase(utils.OrganizationsTestCaseBase):
         )
 
         assert api.get_organizations() == []
-        assert mock_log_info.call_count == 1
+        # One for reactivations, one for creations.
+        assert mock_log_info.call_count == 2
 
     def test_edge_cases(self):
         """
@@ -625,7 +626,8 @@ class BulkAddOrganizationCoursesTestCase(utils.OrganizationsTestCaseBase):
         api.bulk_add_organization_courses([(org_a, course_key_x)], dry_run=True)
 
         assert api.get_organization_courses(org_a) == []
-        assert mock_log_info.call_count == 1
+        # One for reactivations, one for creations.
+        assert mock_log_info.call_count == 2
 
     def test_edge_cases(self):
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,9 @@
 [pycodestyle]
-ignore=E501
+ignore=E501,W503
+# W503 is "line break after binary operator".
+# We must disable either W503 or W504 ("line break before binary operator")
+# if we want it to be at all possible to split conditionals over multiple lines.
+# The choice to disable W503 instead of W504 was arbitrary.
 max_line_length=119
 exclude=settings,migrations
 


### PR DESCRIPTION
The dry run will log what orgs/org-courses would be created,
but it does not apply the changes.

Also, improves logging a bit so that we actually log the orgs
and org-courses that will be *re*-activated. Currently,
we log those that are *existing*, which is a superset of those
that will be re-activated.

For use in bulk_create_orgs_and_org_courses Studio management
command.

Bump version from 6.1.0 to 6.2.0

https://openedx.atlassian.net/browse/TNL-7646