### PR TITLE
Fixes to bulk-creation queries

### DIFF
--- a/organizations/__init__.py
+++ b/organizations/__init__.py
@@ -1,4 +1,4 @@
 """
 edx-organizations app initialization module
 """
-__version__ = '6.2.0'  # pragma: no cover
+__version__ = '6.3.0'  # pragma: no cover

--- a/organizations/tests/test_api.py
+++ b/organizations/tests/test_api.py
@@ -486,7 +486,9 @@ class BulkAddOrganizationsTestCase(utils.OrganizationsTestCaseBase):
         Test that bulk_add_organizations handles a few edge cases as expected.
         """
         # Add three orgs, and remove all but the first.
-        api.add_organization(self.make_organization_data("existing_org"))
+        # Use capitalized name to confirm case insensitivity when checking
+        # for existing orgs.
+        api.add_organization(self.make_organization_data("EXISTING_ORG"))
         api.remove_organization(
             api.add_organization(
                 self.make_organization_data("org_to_reactivate")
@@ -532,7 +534,7 @@ class BulkAddOrganizationsTestCase(utils.OrganizationsTestCaseBase):
         assert {
             organization["short_name"] for organization in organizations
         } == {
-            "existing_org", "org_to_reactivate", "org_X", "org_Y"
+            "EXISTING_ORG", "org_to_reactivate", "org_X", "org_Y"
         }
 
         # Organization dicts with already-taken short_names shouldn't have modified

--- a/organizations/tests/test_api.py
+++ b/organizations/tests/test_api.py
@@ -679,11 +679,12 @@ class BulkAddOrganizationCoursesTestCase(utils.OrganizationsTestCaseBase):
         api.add_organization_course(org_a, course_key_z)
         api.remove_organization_course(org_a, course_key_z)
 
-        # 1 query to load list of existing org-courses,
-        # 1 query to fetch related organizations,
-        # 1 query for activate-existing,
-        # 1 query for create-new.
-        with self.assertNumQueries(4):
+        # 1 query to load list of existing linkages,
+        # 1 query to fetch organizations for existing linkages,
+        # 1 query to ensure all existing linkages active,
+        # 1 query to get organiations for new linkages,
+        # 1 query to create new linkages.
+        with self.assertNumQueries(5):
             api.bulk_add_organization_courses([
 
                 # A->X: Existing linkage, should be a no-op.
@@ -755,11 +756,12 @@ class BulkAddOrganizationCoursesTestCase(utils.OrganizationsTestCaseBase):
         api.add_organization_course(org_a, course_key_y)
         api.remove_organization_course(org_a, course_key_y)
 
-        # 1 query to load list of existing org-courses,
-        # 1 query to fetch related organizations,
-        # 1 query for activate-existing,
-        # 1 query for create-new.
-        with self.assertNumQueries(4):
+        # 1 query to load list of existing linkages,
+        # 1 query to fetch organizations for existing linkages,
+        # 1 query to ensure all existing linkages active,
+        # 1 query to get organiations for new linkages,
+        # 1 query to create new linkages.
+        with self.assertNumQueries(5):
             api.bulk_add_organization_courses([
                 (org_a, course_key_x),  # Already existing.
                 (org_a, course_key_x),  # Already existing.


### PR DESCRIPTION
## Commits

1. Fix query for existing organizations in bulk-add command

   The original query was only worked if organizations were
   stored in the database as lowercase.

2. Fix query to bulk-create organization-course linkages

   The original query failed on certain backends because it
   tried created Organization-Course linkages without first
   setting the primary keys of the Organization instances.
   The original query was only worked if organizations were
   stored in the database as lowercase.

3. Bump version to 6.3.0

## Ticket

https://openedx.atlassina.net/browse/TNL-7646