### PR TITLE
Stop checking for FEATURES['ORGANIZATIONS_APP'] setting

### DIFF
--- a/organizations/__init__.py
+++ b/organizations/__init__.py
@@ -1,4 +1,4 @@
 """
 edx-organizations app initialization module
 """
-__version__ = '6.3.0'  # pragma: no cover
+__version__ = '6.4.0'  # pragma: no cover

--- a/organizations/api.py
+++ b/organizations/api.py
@@ -286,15 +286,4 @@ def is_autocreate_enabled():
     try:
         return bool(settings.ORGANIZATIONS_AUTOCREATE)
     except AttributeError:
-        pass
-    # TODO DEPR-117
-    # ORGANIZATIONS_APP is the (soon-to-be-)deprecated feature flag
-    # that enabled edx-organizations in edx-platform.
-    # To ease migration, we accept the enabling of the old feature flag as a way of
-    # disabling automatic organization creation.
-    try:
-        features = settings.FEATURES
-    except AttributeError:
-        features = {}
-    old_organizations_flag_enabled = bool(features.get('ORGANIZATIONS_APP', False))
-    return not old_organizations_flag_enabled
+        return True

--- a/organizations/tests/test_api.py
+++ b/organizations/tests/test_api.py
@@ -432,14 +432,6 @@ class OrganizationsApiTestCase(utils.OrganizationsTestCaseBase):
         """
         assert api.is_autocreate_enabled()
 
-    @override_settings(FEATURES={"ORGANIZATIONS_APP": True})
-    def test_autocreate_disabled_by_organizations_app(self):
-        """
-        Tests that enabling FEATURES['ORGANIZATIONS_APP'] has the effect of
-        disabling automatic organization creation.
-        """
-        assert not api.is_autocreate_enabled()
-
 
 class BulkAddOrganizationsTestCase(utils.OrganizationsTestCaseBase):
     """


### PR DESCRIPTION
We originally checked the deprecated
`FEATURES['ORGANIZATIONS_APP']` setting
as an alternative to the new `ORGANIZATIONS_AUTOCREATE`
settting, but since we're going to
give `ORGANIZATIONS_AUTOCREATE` a default value in
edx-platform anyway, the fallback check will never
even be reached. Having the fallback check in the
edx-organizations codebase is more misleading than
anything else.

This is effectively a no-op change.

Bump version to 6.4.0

Related to [TNL-7646](https://openedx.atlassian.net/browse/TNL-7646).