### PR TITLE
Return bulk-add results instead of logging them

### DIFF
--- a/organizations/__init__.py
+++ b/organizations/__init__.py
@@ -1,4 +1,4 @@
 """
 edx-organizations app initialization module
 """
-__version__ = '6.4.0'  # pragma: no cover
+__version__ = '6.5.0'  # pragma: no cover


### PR DESCRIPTION
`api.bulk_add_organization` and `api.bulk_add_organization_courses`
previously logged the organizations and organization-course linkages
they were about to create/reactivate.

This was somewhat helpful, but parsing the log output by
hand is more time-consuming and error prone than
simply returning the data and allowing the caller decide
how to process it

https://openedx.atlassian.net/browse/TNL-7774

________________________________

we will use this into edx-platform here: https://github.com/edx/edx-platform/pull/25880