### PR TITLE
[BD-14] Allow organizations and linkages to be bulk-added as inactive

### DIFF
--- a/organizations/__init__.py
+++ b/organizations/__init__.py
@@ -1,4 +1,4 @@
 """
 edx-organizations app initialization module
 """
-__version__ = '6.5.0'  # pragma: no cover
+__version__ = '6.6.0'  # pragma: no cover

--- a/organizations/api.py
+++ b/organizations/api.py
@@ -51,7 +51,7 @@ def add_organization(organization_data):
     return organization
 
 
-def bulk_add_organizations(organization_data_items, dry_run=False):
+def bulk_add_organizations(organization_data_items, dry_run=False, activate=True):
     """
     Efficiently store multiple organizations.
 
@@ -83,6 +83,13 @@ def bulk_add_organizations(organization_data_items, dry_run=False):
             If True, don't apply changes, but still return organizations
             that would have been created or reactivated.
 
+        activate (bool):
+            Optional, defaulting to True.
+            If True, missing organizations will be created with active=True,
+            and existing-but-inactive organizations will be reactivated.
+            If False, missing organizations will be created with active=False,
+            and existing-but-inactive organizations will be left as inactive.
+
     Raises:
         InvalidOrganizationException: One or more organization dictionaries
             have missing or invalid data; no organizations were created.
@@ -93,6 +100,9 @@ def bulk_add_organizations(organization_data_items, dry_run=False):
             short names of organizations that were newly created,
             short names of organizations that we reactivated
         )
+        If `activate` was supplied as False, the set of reactivated linkages will
+        always be empty.
+
         From an API layer point of view, the organizations that were "added"
         is the union of the organizations that were *newly created* and those
         that were *reactivated*. We distinguish between them in the return
@@ -104,7 +114,9 @@ def bulk_add_organizations(organization_data_items, dry_run=False):
             raise exceptions.InvalidOrganizationException(
                 "Organization is missing short_name: {}".format(organization_data)
             )
-    return data.bulk_create_organizations(organization_data_items, dry_run)
+    return data.bulk_create_organizations(
+        organization_data_items, dry_run=dry_run, activate=activate
+    )
 
 
 def edit_organization(organization_data):
@@ -158,7 +170,11 @@ def add_organization_course(organization_data, course_key):
     )
 
 
-def bulk_add_organization_courses(organization_course_pairs, dry_run=False):
+def bulk_add_organization_courses(
+        organization_course_pairs,
+        dry_run=False,
+        activate=True,
+):
     """
     Efficiently store multiple organization-course relationships.
 
@@ -181,6 +197,13 @@ def bulk_add_organization_courses(organization_course_pairs, dry_run=False):
             If True, don't apply changes, but still return organization-course
             linkages that would have been created or reactivated.
 
+        activate (bool):
+            Optional, defaulting to True.
+            If True, missing linkages will be created with active=True,
+            and existing-but-inactive linkages will be reactivated.
+            If False, missing linkages will be created with active=False,
+            and existing-but-inactive linkages will be left as inactive.
+
     Raises:
         InvalidOrganizationException: One or more organization dictionaries
             have missing or invalid data.
@@ -197,6 +220,8 @@ def bulk_add_organization_courses(organization_course_pairs, dry_run=False):
             organization-course linkages that we reactivated
         )
         where the `str` objects are organization short names.
+        If `activate` was supplied as False, the set of reactivated linkages will
+        always be empty.
 
         From an API layer point of view, the organization-
         course linkages that were "added" is the union of the linkages that were
@@ -211,7 +236,9 @@ def bulk_add_organization_courses(organization_course_pairs, dry_run=False):
                 "Organization is missing short_name: {}".format(organization_data)
             )
         _validate_course_key(course_key)
-    return data.bulk_create_organization_courses(organization_course_pairs, dry_run)
+    return data.bulk_create_organization_courses(
+        organization_course_pairs, dry_run=dry_run, activate=activate
+    )
 
 
 def get_organization_courses(organization_data):

--- a/organizations/data.py
+++ b/organizations/data.py
@@ -139,7 +139,7 @@ def create_organization(organization):
     return serializers.serialize_organization(organization)
 
 
-def bulk_create_organizations(organizations, dry_run=False):
+def bulk_create_organizations(organizations, dry_run=False, activate=True):
     """
     Efficiently insert multiple organizations into the database.
 
@@ -167,20 +167,32 @@ def bulk_create_organizations(organizations, dry_run=False):
             If True, don't apply changes, but still return organizations
             that would have been created or reactivated.
 
+        activate (bool):
+            Optional, defaulting to True.
+            If True, missing organizations will be created with active=True,
+            and existing-but-inactivate organizations will be reactivated.
+            If False, missing organizations will be created with active=False,
+            and existing-but-inactivate organizations will be left as inactivate.
+
     Returns: tuple[set[str], set[str]]
 
         A tuple in the form: (
             short names of organizations that were newly created,
             short names of organizations that we reactivated
         )
+        If `activate` was supplied as False, the set of reactivated organizations
+        will always be empty.
     """
     # Collect organizations by short name, dropping conflicts as necessary.
     organization_objs = [
         # This deserializes the dictionaries into Organization instances that
-        # have not yet been saved to the db. By default, they all have `active=True`.
+        # have not yet been saved to the db.
         serializers.deserialize_organization(organization_dict)
         for organization_dict in organizations
     ]
+    # Make sure `active` is set correctly on the deserialized organizations.
+    for organization_obj in organization_objs:
+        organization_obj.active = activate
     organizations_by_short_name = {}
     for organization in organization_objs:
         # Make sure to lowercase short_name because MySQL UNIQUE is case-insensitive.
@@ -210,7 +222,11 @@ def bulk_create_organizations(organizations, dry_run=False):
         for short_name, organization in organizations_by_short_name.items()
         if short_name.lower() not in existing_organization_short_names
     ]
-    organizations_to_reactivate = existing_organizations.filter(active=False)
+    organizations_to_reactivate = (
+        existing_organizations.filter(active=False)
+        if activate
+        else internal.Organization.objects.none()
+    )
 
     # Collect sets of orgs that will be reactivated and created,
     # so that we can have an informative return value.
@@ -223,6 +239,7 @@ def bulk_create_organizations(organizations, dry_run=False):
 
     # If not a dry run,
     # re-activate existing organizations, and create the new ones.
+    # If `activate==False`, then `organizations_to_reactivate` will be empty.
     if not dry_run:
         organizations_to_reactivate.update(active=True)
         internal.Organization.objects.bulk_create(organizations_to_create)
@@ -322,7 +339,11 @@ def create_organization_course(organization, course_key):
         )
 
 
-def bulk_create_organization_courses(organization_course_pairs, dry_run=False):
+def bulk_create_organization_courses(
+        organization_course_pairs,
+        dry_run=False,
+        activate=True,
+):
     """
     Efficiently insert multiple organization-course relationships into the database.
 
@@ -342,6 +363,13 @@ def bulk_create_organization_courses(organization_course_pairs, dry_run=False):
             If True, don't apply changes, but still return organization-course
             linkages that would have been created or reactivated.
 
+        activate (bool):
+            Optional, defaulting to True.
+            If True, missing linkages will be created with active=True,
+            and existing-but-inactive linkages will be reactivated.
+            If False, missing linkages will be created with active=False,
+            and existing-but-inactive linkages will be left as inactive.
+
     Returns: tuple[
                 set[tuple[str, str]],
                 set[tuple[str, str]]
@@ -353,6 +381,8 @@ def bulk_create_organization_courses(organization_course_pairs, dry_run=False):
         )
         where an "organization-course" linkage is a tuple in the form:
             (organization short name, course key string).
+        If `activate` was supplied as False, the set of reactivated linkages will
+        always be empty.
     """
     def linkage_to_pair(linkage):
         """
@@ -392,10 +422,11 @@ def bulk_create_organization_courses(organization_course_pairs, dry_run=False):
 
     # The set of org-course linkages that we must ENSURE ARE ACTIVE
     # is the set of linkages that were REQUESTED
-    # minus the set of linkages that WILL BE CREATED.
+    # minus the set of linkages that WILL BE CREATED,
+    # unless activate==False, in which case we won't ensure anything is active.
     linkage_pairs_to_ensure_active = (
         requested_linkage_pairs - linkage_pairs_to_create
-    )
+    ) if activate else set()
 
     # The linkages we must REACTIVATE
     # are those that we must ENSURE ARE ACTIVE
@@ -418,6 +449,7 @@ def bulk_create_organization_courses(organization_course_pairs, dry_run=False):
         return linkage_pairs_to_create, linkage_pairs_to_reactivate
 
     # Bulk-reactivate existing organization-course linkages.
+    # If `ids_of_linkages_to_reactivate` is an empty set, then this is a no-op.
     ids_of_linkages_to_reactivate = {linkage.id for linkage in linkages_to_reactivate}
     internal.OrganizationCourse.objects.filter(
         id__in=ids_of_linkages_to_reactivate
@@ -441,7 +473,7 @@ def bulk_create_organization_courses(organization_course_pairs, dry_run=False):
         internal.OrganizationCourse(
             organization=organizations_for_create_by_short_name[org_short_name],
             course_id=course_id,
-            active=True,
+            active=activate,
         )
         for org_short_name, course_id
         in linkage_pairs_to_create

--- a/organizations/data.py
+++ b/organizations/data.py
@@ -222,11 +222,10 @@ def bulk_create_organizations(organizations, dry_run=False, activate=True):
         for short_name, organization in organizations_by_short_name.items()
         if short_name.lower() not in existing_organization_short_names
     ]
-    organizations_to_reactivate = (
-        existing_organizations.filter(active=False)
-        if activate
-        else internal.Organization.objects.none()
-    )
+    if activate:
+        organizations_to_reactivate = existing_organizations.filter(active=False)
+    else:
+        organizations_to_reactivate = internal.Organization.objects.none()
 
     # Collect sets of orgs that will be reactivated and created,
     # so that we can have an informative return value.
@@ -424,9 +423,10 @@ def bulk_create_organization_courses(
     # is the set of linkages that were REQUESTED
     # minus the set of linkages that WILL BE CREATED,
     # unless activate==False, in which case we won't ensure anything is active.
-    linkage_pairs_to_ensure_active = (
-        requested_linkage_pairs - linkage_pairs_to_create
-    ) if activate else set()
+    if activate:
+        linkage_pairs_to_ensure_active = requested_linkage_pairs - linkage_pairs_to_create
+    else:
+        linkage_pairs_to_ensure_active = set()
 
     # The linkages we must REACTIVATE
     # are those that we must ENSURE ARE ACTIVE


### PR DESCRIPTION
## Change

Add a new optional flag `activate` to both:
  * `api.bulk_add_organizations` and
  * `api.bulk_add_organization_courses`,

defaulting to `True`, which is the current behavior.

With `activate=False`, those functions will set the `active` flag on newly created objects to False. Furthermore, they will not re-activate any existing objects. This is in contrast to the default behavior (`activate=True`) which creates new objects with `active` as True and re-activates matching existing objects.

Bump version to 6.6.0

## Reasoning

After talking to Data Engineering, we decided that it'd be good to be able to tell what organization data on edx.org was automatically created as the result of the backfill (as opposed to manually created by edX staff via the authoritative Discovery database). We'd discussed having an `automatically_created` field, which could be set to `True` in the case of the backfilled records.

After thinking this over, I believe it'd be better just to allow records to be created as inactive, because:
1. On environments where `ORGANIZATIONS_AUTOCREATE==True`, like edge.edx.org, a field like `automatically_created` would be superfluous, since all records are created automatically. For these environments, it makes the most sense just to create backfill records like any other record.
2. On courses.edx.org, we expect that all active Edxapp Organizations records synced from the upstream Discovery Organizations tables. Running this backfill on courses.edx.org would break that expectation, *unless* we create the records on courses.edx.org as "inactive". Semantically, it also makes sense that any Organization created by the backfill on courses.edx.org is not one that we want to actively exist--if that were the case, then the Organization would already exist in Discovery (and therefore also in the Edxapp database).
3. If an upstream Organizations API user (like Discovery) ever wishes to *manually create* an inactive backfilled Organization, then edx-organizations will handle this nicely by simply activating the backfilled organization.

## Result

On **prod-edx** and **stage-edx**, we will now run:
```shell
./manage.py cms backfill_orgs_and_org_courses --inactive
```

On **prod-edge**, we will still run:
```shell
./manage.py cms backfill_orgs_and_org_courses
```

## Links

Part of [TNL-7774](https://openedx.atlassian.net/browse/TNL-7774).

Corresponding edx-platform PR: https://github.com/edx/edx-platform/pull/25976