### PR TITLE
Deploy with Python38

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ deploy:
   user: edx
   distributions: sdist bdist_wheel
   on:
-    python: 3.5
+    python: 3.8
     tags: true
     condition: $TOXENV = quality
     repo: edx/edx-organizations

--- a/organizations/__init__.py
+++ b/organizations/__init__.py
@@ -1,4 +1,4 @@
 """
 edx-organizations app initialization module
 """
-__version__ = '6.7.0'  # pragma: no cover
+__version__ = '6.7.1'  # pragma: no cover


### PR DESCRIPTION
Deploy on PyPI with `python38` and bump the version to `6.7.1`.