### PR TITLE
fix: period inside short name returns 404

### DIFF
--- a/organizations/v0/views.py
+++ b/organizations/v0/views.py
@@ -25,6 +25,8 @@ class OrganizationsViewSet(mixins.UpdateModelMixin, viewsets.ReadOnlyModelViewSe
     """
     queryset = Organization.objects.all()
     serializer_class = OrganizationSerializer
+    # Include everything not a '+' - identical to discovery's COURSE_ID_REGEX.
+    lookup_value_regex = '[^/+]+'
     lookup_field = 'short_name'
     authentication_classes = (JwtAuthentication, SessionAuthentication)
     permission_classes = (IsAuthenticated, UserIsStaff)


### PR DESCRIPTION
API calls returing 404 if short name contains a period e.g. test.com. Added `lookup_value_regex` field with custom regex to fix it.

<img width="1403" alt="Screenshot 2022-03-11 at 2 43 10 PM" src="https://user-images.githubusercontent.com/2851134/158401026-f8055f80-3710-42e8-9eb1-3284c007ffd6.png">

DISCO-1800